### PR TITLE
 add legacy auth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ enabled=True
 url=https://path.to/your/subsonic/server
 username=subsonic_username
 password=your_secret_password
-legacy_auth = (optional; setting to yes may solve some connection errors)
+legacy_auth=(optional; setting to yes may solve some connection errors)
 ```
 
 ## State of this plugin

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ enabled=True
 url=https://path.to/your/subsonic/server
 username=subsonic_username
 password=your_secret_password
+legacy_auth = (optional; setting to yes may solve some connection errors)
 ```
 
 ## State of this plugin

--- a/mopidy_subidy/__init__.py
+++ b/mopidy_subidy/__init__.py
@@ -22,6 +22,7 @@ class SubidyExtension(ext.Extension):
         schema['url'] = config.String()
         schema['username'] = config.String()
         schema['password'] = config.Secret()
+        schema['legacy_auth'] = config.Boolean(optional=True)
         return schema
 
     def setup(self, registry):

--- a/mopidy_subidy/backend.py
+++ b/mopidy_subidy/backend.py
@@ -9,7 +9,8 @@ class SubidyBackend(pykka.ThreadingActor, backend.Backend):
         self.subsonic_api = subsonic_api.SubsonicApi(
             url=subidy_config['url'],
             username=subidy_config['username'],
-            password=subidy_config['password'])
+            password=subidy_config['password'],
+            legacy_auth=subidy_config['legacy_auth'])
         self.library = library.SubidyLibraryProvider(backend=self)
         self.playback = playback.SubidyPlaybackProvider(audio=audio, backend=self)
         self.playlists = playlists.SubidyPlaylistsProvider(backend=self)

--- a/mopidy_subidy/ext.conf
+++ b/mopidy_subidy/ext.conf
@@ -3,4 +3,4 @@ enabled = true
 url =
 username =
 password =
-
+legacy_auth = no

--- a/mopidy_subidy/subsonic_api.py
+++ b/mopidy_subidy/subsonic_api.py
@@ -16,7 +16,7 @@ MAX_SEARCH_RESULTS = 100
 ref_sort_key = lambda ref: ref.name
 
 class SubsonicApi():
-    def __init__(self, url, username, password):
+    def __init__(self, url, username, password, legacy_auth):
         parsed = urlparse(url)
         self.port = parsed.port if parsed.port else \
             443 if parsed.scheme == 'https' else 80
@@ -26,7 +26,8 @@ class SubsonicApi():
             username,
             password,
             self.port,
-            parsed.path + '/rest')
+            parsed.path + '/rest',
+            legacyAuth=legacy_auth)
         self.url = url + '/rest'
         self.username = username
         self.password = password


### PR DESCRIPTION
This pull allows connecting using older (pre-1.13) auth.

See crustymonkey/py-sonic#17 and rattboi/mopidy-subsonic#24 for more information.