### PR TITLE
py-sonic minimum version to support legacy auth

### DIFF
--- a/mopidy_subidy/subsonic_api.py
+++ b/mopidy_subidy/subsonic_api.py
@@ -27,7 +27,7 @@ class SubsonicApi():
             password,
             self.port,
             parsed.path + '/rest',
-            legacy_auth)
+            legacyAuth=legacy_auth)
         self.url = url + '/rest'
         self.username = username
         self.password = password

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     install_requires=[
         'setuptools',
         'Mopidy >= 2.0',
-        'py-sonic',
+        'py-sonic >= 0.6.1',
         'Pykka >= 1.1'
     ],
     entry_points={


### PR DESCRIPTION
Didn't realize until #6 was merged, but py-sonic must be at least version 0.6.1 for `legacyAuth=<boolean>` to work. So added that as min version, and reintroduced keyword parameter, since the next positional ` parameter is appName`, which is currently set to `legacy_auth`'s value.

I hope requiring the newer version is OK with you :-)

Thanks! :-)