### PR TITLE
Sort directory API results

### DIFF
--- a/mopidy_subidy/subsonic_api.py
+++ b/mopidy_subidy/subsonic_api.py
@@ -3,6 +3,7 @@ import libsonic
 import logging
 import itertools
 from mopidy.models import Track, Album, Artist, Playlist, Ref, SearchResult
+import re
 from mopidy_subidy import uri
 
 logger = logging.getLogger(__name__)
@@ -14,6 +15,8 @@ UNKNOWN_ARTIST = u'Unknown Artist'
 MAX_SEARCH_RESULTS = 100
 
 ref_sort_key = lambda ref: ref.name
+
+string_nums_nocase_sort_key = lambda s: tuple((int(i) if i.isdigit() else i.lower()) for i in re.split(r'(\d+)', s))
 
 class SubsonicApi():
     def __init__(self, url, username, password, legacy_auth):
@@ -159,7 +162,7 @@ class SubsonicApi():
         directory = response.get('directory')
         if directory is not None:
             diritems = directory.get('child')
-            sorted_diritems = sorted(diritems, key=lambda a: (a['isDir'], (a['title'] if a['isDir'] else int(a['track']))))
+            sorted_diritems = sorted(diritems, key=lambda a: (a['isDir'], (string_nums_nocase_sort_key(a['title']) if a['isDir'] else int(a['track']))))
             return sorted_diritems
         return None
 

--- a/mopidy_subidy/subsonic_api.py
+++ b/mopidy_subidy/subsonic_api.py
@@ -16,7 +16,7 @@ MAX_SEARCH_RESULTS = 100
 
 ref_sort_key = lambda ref: ref.name
 
-string_nums_nocase_sort_key = lambda s: tuple((int(i) if i.isdigit() else i.lower()) for i in re.split(r'(\d+)', s))
+string_nums_nocase_sort_key = lambda s: [(int(i) if i.isdigit() else i.lower()) for i in re.split(r'(\d+)', s)]
 
 class SubsonicApi():
     def __init__(self, url, username, password, legacy_auth):

--- a/mopidy_subidy/subsonic_api.py
+++ b/mopidy_subidy/subsonic_api.py
@@ -18,6 +18,14 @@ ref_sort_key = lambda ref: ref.name
 
 string_nums_nocase_sort_key = lambda s: [(int(i) if i.isdigit() else i.lower()) for i in re.split(r'(\d+)', s)]
 
+def diritem_sort_key(item):
+    isdir = item['isDir']
+    if isdir:
+        key = string_nums_nocase_sort_key(item['title'])
+    else:
+        key = int(item['track'])
+    return (isdir, key)
+
 class SubsonicApi():
     def __init__(self, url, username, password, legacy_auth):
         parsed = urlparse(url)
@@ -162,8 +170,7 @@ class SubsonicApi():
         directory = response.get('directory')
         if directory is not None:
             diritems = directory.get('child')
-            sorted_diritems = sorted(diritems, key=lambda a: (a['isDir'], (string_nums_nocase_sort_key(a['title']) if a['isDir'] else int(a['track']))))
-            return sorted_diritems
+            return sorted(diritems, key=diritem_sort_key)
         return None
 
     def get_raw_albums(self, artist_id):

--- a/mopidy_subidy/subsonic_api.py
+++ b/mopidy_subidy/subsonic_api.py
@@ -16,7 +16,15 @@ MAX_SEARCH_RESULTS = 100
 
 ref_sort_key = lambda ref: ref.name
 
-string_nums_nocase_sort_key = lambda s: [(int(i) if i.isdigit() else i.lower()) for i in re.split(r'(\d+)', s)]
+def string_nums_nocase_sort_key(s):
+    segments = []
+    for substr in re.split(r'(\d+)', s):
+        if substr.isdigit():
+            seg = int(substr)
+        else:
+            seg = substr.lower()
+        segments.append(seg)
+    return segments
 
 def diritem_sort_key(item):
     isdir = item['isDir']

--- a/mopidy_subidy/subsonic_api.py
+++ b/mopidy_subidy/subsonic_api.py
@@ -158,7 +158,9 @@ class SubsonicApi():
             return None
         directory = response.get('directory')
         if directory is not None:
-            return directory.get('child')
+            diritems = directory.get('child')
+            sorted_diritems = sorted(diritems, key=lambda a: (a['isDir'], (a['title'] if a['isDir'] else int(a['track']))))
+            return sorted_diritems
         return None
 
     def get_raw_albums(self, artist_id):


### PR DESCRIPTION
This sorts <a href="http://www.subsonic.org/pages/api.jsp#getMusicDirectory">`getMusicDirectory`</a> results, in case they have not already been sorted (by the server).

Strings are sorted with a <a href="https://en.wikipedia.org/wiki/Natural_sort_order">natural sort</a> and case-insensitively (capitals do not come before all lowercases like with ASCII sorting).

I have encountered non-sorted directory entries on occasion with <a href="https://github.com/spl0k/supysonic">Supysonic</a>.