### PR TITLE
Lookup items as tracks

### DIFF
--- a/mopidy_subidy/library.py
+++ b/mopidy_subidy/library.py
@@ -59,7 +59,7 @@ class SubidyLibraryProvider(backend.LibraryProvider):
         return self.subsonic_api.get_song_by_id(song_id)
 
     def lookup_album(self, album_id):
-        return self.subsonic_api.get_album_by_id(album_id)
+        return self.subsonic_api.get_songs_as_tracks(album_id)
 
     def lookup_artist(self, artist_id):
         return self.subsonic_api.get_artist_by_id(artist_id)
@@ -94,13 +94,13 @@ class SubidyLibraryProvider(backend.LibraryProvider):
         if type == uri.ALBUM:
             return self.lookup_album(uri.get_album_id(lookup_uri))
         if type == uri.SONG:
-            return self.lookup_song(uri.get_song_id(lookup_uri))
+            return [self.lookup_song(uri.get_song_id(lookup_uri))]
 
     def lookup(self, uri=None, uris=None):
         if uris is not None:
-            return [self.lookup_one(uri) for uri in uris]
+            return dict((uri, self.lookup_one(uri)) for uri in uris)
         if uri is not None:
-            return [self.lookup_one(uri)]
+            return self.lookup_one(uri)
         return None
 
     def refresh(self, uri):

--- a/mopidy_subidy/library.py
+++ b/mopidy_subidy/library.py
@@ -64,6 +64,9 @@ class SubidyLibraryProvider(backend.LibraryProvider):
     def lookup_artist(self, artist_id):
         return self.subsonic_api.get_artist_songs_as_tracks(artist_id)
 
+    def lookup_directory(self, directory_id):
+        return self.subsonic_api.get_diritems_as_tracks(directory_id)
+
     def browse(self, browse_uri):
         if browse_uri == uri.get_vdir_uri('root'):
             root_vdir_names = ["rootdirs", "artists", "albums"]
@@ -93,6 +96,8 @@ class SubidyLibraryProvider(backend.LibraryProvider):
             return self.lookup_artist(uri.get_artist_id(lookup_uri))
         if type == uri.ALBUM:
             return self.lookup_album(uri.get_album_id(lookup_uri))
+        if type == uri.DIRECTORY:
+            return self.lookup_directory(uri.get_directory_id(lookup_uri))
         if type == uri.SONG:
             return [self.lookup_song(uri.get_song_id(lookup_uri))]
 

--- a/mopidy_subidy/library.py
+++ b/mopidy_subidy/library.py
@@ -62,7 +62,7 @@ class SubidyLibraryProvider(backend.LibraryProvider):
         return self.subsonic_api.get_songs_as_tracks(album_id)
 
     def lookup_artist(self, artist_id):
-        return self.subsonic_api.get_artist_by_id(artist_id)
+        return self.subsonic_api.get_artist_songs_as_tracks(artist_id)
 
     def browse(self, browse_uri):
         if browse_uri == uri.get_vdir_uri('root'):

--- a/mopidy_subidy/library.py
+++ b/mopidy_subidy/library.py
@@ -62,7 +62,7 @@ class SubidyLibraryProvider(backend.LibraryProvider):
         return self.subsonic_api.get_songs_as_tracks(album_id)
 
     def lookup_artist(self, artist_id):
-        return self.subsonic_api.get_artist_songs_as_tracks(artist_id)
+        return self.subsonic_api.get_artist_as_songs_as_tracks(artist_id)
 
     def lookup_directory(self, directory_id):
         return self.subsonic_api.get_diritems_as_tracks(directory_id)

--- a/mopidy_subidy/library.py
+++ b/mopidy_subidy/library.py
@@ -62,10 +62,10 @@ class SubidyLibraryProvider(backend.LibraryProvider):
         return self.subsonic_api.get_songs_as_tracks(album_id)
 
     def lookup_artist(self, artist_id):
-        return self.subsonic_api.get_artist_as_songs_as_tracks(artist_id)
+        return list(self.subsonic_api.get_artist_as_songs_as_tracks_iter(artist_id))
 
     def lookup_directory(self, directory_id):
-        return self.subsonic_api.get_diritems_as_tracks(directory_id)
+        return list(self.subsonic_api.get_recursive_dir_as_songs_as_tracks_iter(directory_id))
 
     def browse(self, browse_uri):
         if browse_uri == uri.get_vdir_uri('root'):

--- a/mopidy_subidy/library.py
+++ b/mopidy_subidy/library.py
@@ -100,6 +100,7 @@ class SubidyLibraryProvider(backend.LibraryProvider):
             return self.lookup_directory(uri.get_directory_id(lookup_uri))
         if type == uri.SONG:
             return [self.lookup_song(uri.get_song_id(lookup_uri))]
+        # TODO: uri.PLAYLIST
 
     def lookup(self, uri=None, uris=None):
         if uris is not None:

--- a/mopidy_subidy/library.py
+++ b/mopidy_subidy/library.py
@@ -71,6 +71,9 @@ class SubidyLibraryProvider(backend.LibraryProvider):
     def lookup_directory(self, directory_id):
         return list(self.subsonic_api.get_recursive_dir_as_songs_as_tracks_iter(directory_id))
 
+    def lookup_playlist(self, playlist_id):
+        return self.subsonic_api.get_playlist_as_playlist(playlist_id).tracks
+
     def browse(self, browse_uri):
         if browse_uri == uri.get_vdir_uri('root'):
             root_vdir_names = ["rootdirs", "artists", "albums"]
@@ -104,7 +107,8 @@ class SubidyLibraryProvider(backend.LibraryProvider):
             return self.lookup_directory(uri.get_directory_id(lookup_uri))
         if type == uri.SONG:
             return self.lookup_song(uri.get_song_id(lookup_uri))
-        # TODO: uri.PLAYLIST
+        if type == uri.PLAYLIST:
+            return self.lookup_playlist(uri.get_playlist_id(lookup_uri))
 
     def lookup(self, uri=None, uris=None):
         if uris is not None:

--- a/mopidy_subidy/library.py
+++ b/mopidy_subidy/library.py
@@ -56,7 +56,11 @@ class SubidyLibraryProvider(backend.LibraryProvider):
         return self.subsonic_api.get_diritems_as_refs(directory_id)
 
     def lookup_song(self, song_id):
-        return self.subsonic_api.get_song_by_id(song_id)
+        song = self.subsonic_api.get_song_by_id(song_id)
+        if song is None:
+            return []
+        else:
+            return [song]
 
     def lookup_album(self, album_id):
         return self.subsonic_api.get_songs_as_tracks(album_id)
@@ -99,7 +103,7 @@ class SubidyLibraryProvider(backend.LibraryProvider):
         if type == uri.DIRECTORY:
             return self.lookup_directory(uri.get_directory_id(lookup_uri))
         if type == uri.SONG:
-            return [self.lookup_song(uri.get_song_id(lookup_uri))]
+            return self.lookup_song(uri.get_song_id(lookup_uri))
         # TODO: uri.PLAYLIST
 
     def lookup(self, uri=None, uris=None):

--- a/mopidy_subidy/subsonic_api.py
+++ b/mopidy_subidy/subsonic_api.py
@@ -292,7 +292,7 @@ class SubsonicApi():
             return None
         return [self.raw_song_to_ref(song) for song in playlist.get('entry')]
 
-    def get_artist_songs_as_tracks(self, artist_id):
+    def get_artist_as_songs_as_tracks(self, artist_id):
         albums = self.get_raw_albums(artist_id)
         if albums is None:
             return None

--- a/mopidy_subidy/subsonic_api.py
+++ b/mopidy_subidy/subsonic_api.py
@@ -289,6 +289,12 @@ class SubsonicApi():
             return None
         return [self.raw_song_to_ref(song) for song in playlist.get('entry')]
 
+    def get_artist_songs_as_tracks(self, artist_id):
+        albums = self.get_raw_albums(artist_id)
+        if albums is None:
+            return None
+        return [self.raw_song_to_track(song) for album in albums for song in self.get_raw_songs(album.get('id'))]
+
     def raw_song_to_ref(self, song):
         if song is None:
             return None

--- a/mopidy_subidy/subsonic_api.py
+++ b/mopidy_subidy/subsonic_api.py
@@ -271,6 +271,9 @@ class SubsonicApi():
     def get_diritems_as_refs(self, directory_id):
         return [(self.raw_directory_to_ref(diritem) if diritem.get('isDir') else self.raw_song_to_ref(diritem)) for diritem in self.get_raw_dir(directory_id)]
 
+    def get_diritems_as_tracks(self, directory_id):
+        return [self.raw_song_to_track(diritem) for diritem in self.get_raw_dir(directory_id) if not diritem.get('isDir')]
+
     def get_artists_as_artists(self):
         return [self.raw_artist_to_artist(artist) for artist in self.get_raw_artists()]
 


### PR DESCRIPTION
This pull causes the mopidy `lookup` function to return a list of `Track`s, as specified <a href="https://docs.mopidy.com/en/latest/api/core/#mopidy.core.LibraryController.lookup">here</a>. Other backends seem to do this too, as far as I have seen, at least for albums.