### PR TITLE
API version setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ enabled=True
 url=https://path.to/your/subsonic/server
 username=subsonic_username
 password=your_secret_password
-legacy_auth=(optional; setting to yes may solve some connection errors)
+legacy_auth=(optional - setting to yes may solve some connection errors)
+api_version=(optional - specify which API version to use. Subsonic 6.2 uses 1.14.0)
 ```
 
 ## State of this plugin

--- a/mopidy_subidy/__init__.py
+++ b/mopidy_subidy/__init__.py
@@ -23,6 +23,7 @@ class SubidyExtension(ext.Extension):
         schema['username'] = config.String()
         schema['password'] = config.Secret()
         schema['legacy_auth'] = config.Boolean(optional=True)
+        schema['api_version'] = config.String(optional=True)
         return schema
 
     def setup(self, registry):

--- a/mopidy_subidy/backend.py
+++ b/mopidy_subidy/backend.py
@@ -10,7 +10,8 @@ class SubidyBackend(pykka.ThreadingActor, backend.Backend):
             url=subidy_config['url'],
             username=subidy_config['username'],
             password=subidy_config['password'],
-            legacy_auth=subidy_config['legacy_auth'])
+            legacy_auth=subidy_config['legacy_auth'],
+            api_version=subidy_config['api_version'])
         self.library = library.SubidyLibraryProvider(backend=self)
         self.playback = playback.SubidyPlaybackProvider(audio=audio, backend=self)
         self.playlists = playlists.SubidyPlaylistsProvider(backend=self)

--- a/mopidy_subidy/ext.conf
+++ b/mopidy_subidy/ext.conf
@@ -4,3 +4,4 @@ url =
 username =
 password =
 legacy_auth = no
+api_version = 1.14.0

--- a/mopidy_subidy/subsonic_api.py
+++ b/mopidy_subidy/subsonic_api.py
@@ -37,7 +37,7 @@ def diritem_sort_key(item):
     return (isdir, key)
 
 class SubsonicApi():
-    def __init__(self, url, username, password, legacy_auth):
+    def __init__(self, url, username, password, legacy_auth, api_version):
         parsed = urlparse(url)
         self.port = parsed.port if parsed.port else \
             443 if parsed.scheme == 'https' else 80
@@ -48,15 +48,16 @@ class SubsonicApi():
             password,
             self.port,
             parsed.path + '/rest',
-            legacyAuth=legacy_auth)
+            legacyAuth=legacy_auth,
+            apiVersion=api_version)
         self.url = url + '/rest'
         self.username = username
         self.password = password
-        logger.info('Connecting to subsonic server on url %s as user %s' % (url, username))
+        logger.info('Connecting to subsonic server on url %s as user %s, API version %s' % (url, username, api_version))
         try:
             self.connection.ping()
         except Exception as e:
-            logger.error('Unabled to reach subsonic server: %s' % e)
+            logger.error('Unable to reach subsonic server: %s' % e)
             exit()
 
     def get_subsonic_uri(self, view_name, params, censor=False):


### PR DESCRIPTION
The plugin didn't work with Subsonic 5.3, and the same should apply for any Subsonic version older than 6.2 so I added a setting for API version in the config file. Default version is currently "1.14.0", which is the 6.2 version.