### PR TITLE
extension name as subsonic API client name

### DIFF
--- a/mopidy_subidy/backend.py
+++ b/mopidy_subidy/backend.py
@@ -1,3 +1,4 @@
+import mopidy_subidy
 from mopidy_subidy import library, playback, playlists, subsonic_api
 from mopidy import backend
 import pykka
@@ -10,6 +11,7 @@ class SubidyBackend(pykka.ThreadingActor, backend.Backend):
             url=subidy_config['url'],
             username=subidy_config['username'],
             password=subidy_config['password'],
+            app_name=mopidy_subidy.SubidyExtension.dist_name,
             legacy_auth=subidy_config['legacy_auth'],
             api_version=subidy_config['api_version'])
         self.library = library.SubidyLibraryProvider(backend=self)

--- a/mopidy_subidy/subsonic_api.py
+++ b/mopidy_subidy/subsonic_api.py
@@ -37,7 +37,7 @@ def diritem_sort_key(item):
     return (isdir, key)
 
 class SubsonicApi():
-    def __init__(self, url, username, password, legacy_auth, api_version):
+    def __init__(self, url, username, password, app_name, legacy_auth, api_version):
         parsed = urlparse(url)
         self.port = parsed.port if parsed.port else \
             443 if parsed.scheme == 'https' else 80
@@ -48,6 +48,7 @@ class SubsonicApi():
             password,
             self.port,
             parsed.path + '/rest',
+            appName=app_name,
             legacyAuth=legacy_auth,
             apiVersion=api_version)
         self.url = url + '/rest'
@@ -63,7 +64,7 @@ class SubsonicApi():
     def get_subsonic_uri(self, view_name, params, censor=False):
         di_params = {}
         di_params.update(params)
-        di_params.update(c='mopidy')
+        di_params.update(c=self.connection.appName)
         di_params.update(v=self.connection.apiVersion)
         if censor:
             di_params.update(u='*****', p='*****')


### PR DESCRIPTION
This pull makes API requests (both requests using `py-sonic` an "raw" API requests) send the extension `dist_name` (`Mopidy-Subidy` at present) as the subsonic API client name.