### PR TITLE
Remove version range for py-sonic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     install_requires=[
         'setuptools',
         'Mopidy >= 2.0',
-        'py-sonic >= 0.6.1',
+        'py-sonic == 0.6.2',
         'Pykka >= 1.1'
     ],
     entry_points={


### PR DESCRIPTION
py-sonic stopped supporting python2 > 0.6.2
Using pip to install results in an error if this is not set

```
pip install . 
Processing /home/pi/mopidy-subidy
Collecting Mopidy>=2.0 (from Mopidy-Subidy==0.2.1)
  Using cached https://files.pythonhosted.org/packages/1e/1e/6a64a4a27bda7f025f397e0e11b53168dfc83d613605c1969581bc68f644/Mopidy-2.1.0-py2.py3-none-any.whl
Collecting Pykka>=1.1 (from Mopidy-Subidy==0.2.1)
  Using cached https://files.pythonhosted.org/packages/66/cd/89889a1b079385ce9c3e6adc447d20c2f77116c1fb08f65bb23a601be8cb/Pykka-1.2.1-py2.py3-none-any.whl
Collecting py-sonic>=0.6.1 (from Mopidy-Subidy==0.2.1)
  Using cached https://files.pythonhosted.org/packages/e7/ae/4a48ca9010d8f69714f01a223de66949cbe52c233d231479dcaabb4df1a7/py-sonic-0.7.2.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-mcMWRy/py-sonic/setup.py", line 21, in <module>
        from libsonic import __version__ as version
      File "libsonic/__init__.py", line 30, in <module>
        from .connection import *
      File "libsonic/connection.py", line 21, in <module>
        import urllib.request
    ImportError: No module named request
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-mcMWRy/py-sonic/
```