### PR TITLE
Add support for python3

### DIFF
--- a/mopidy_subidy/subsonic_api.py
+++ b/mopidy_subidy/subsonic_api.py
@@ -1,5 +1,5 @@
-from urlparse import urlparse
-from urllib import urlencode
+from urllib.parse import urlparse
+from urllib.parse import urlencode
 import libsonic
 import logging
 import itertools

--- a/setup.py
+++ b/setup.py
@@ -24,11 +24,11 @@ setup(
     install_requires=[
         'setuptools',
         'Mopidy >= 2.0',
-        'py-sonic == 0.6.2',
+        'py-sonic >= 0.7.7',
         'Pykka >= 1.1'
     ],
     entry_points={
-        b'mopidy.ext': [
+        'mopidy.ext': [
             'subidy = mopidy_subidy:SubidyExtension',
         ],
     },


### PR DESCRIPTION
Mopidy no longer supports Python 2.7.
These changes remove support for Python 2.7 in subidy as well