### PR TITLE
Make repeated getAlbumList2 requests with offset to get all albums

### DIFF
--- a/mopidy_subidy/subsonic_api.py
+++ b/mopidy_subidy/subsonic_api.py
@@ -432,12 +432,18 @@ class SubsonicApi:
         return []
 
     def get_raw_album_list(self, ltype, size=MAX_LIST_RESULTS):
+        """
+        Subsonic servers don't offer any way to retrieve the total number
+        of albums to get, and the spec states that the max number returned
+        for `getAlbumList2` is 500.  To get all the albums, we make a
+        `getAlbumList2` request each time the response contains 500 albums. If
+        it does not, we assume we have all the albums and return them.
+        """
         offset = 0
         total = []
         albums = self.get_more_albums(ltype, size, offset)
         total = albums
         while len(albums) == size:
-            # try getting more albums
             offset = offset + size
             albums = self.get_more_albums(ltype, size, offset)
             total = total + albums

--- a/mopidy_subidy/subsonic_api.py
+++ b/mopidy_subidy/subsonic_api.py
@@ -410,9 +410,9 @@ class SubsonicApi:
             return songs
         return []
 
-    def get_raw_album_list(self, ltype, size=MAX_LIST_RESULTS):
+    def get_more_albums(self, ltype, size=MAX_LIST_RESULTS, offset=0):
         try:
-            response = self.connection.getAlbumList2(ltype=ltype, size=size)
+            response = self.connection.getAlbumList2(ltype=ltype, size=size, offset=offset)
         except Exception:
             logger.warning(
                 "Connecting to subsonic failed when loading album list."
@@ -428,6 +428,18 @@ class SubsonicApi:
         if albums is not None:
             return albums
         return []
+
+    def get_raw_album_list(self, ltype, size=MAX_LIST_RESULTS):
+        offset = 0
+        total = []
+        albums = self.get_more_albums(ltype, size, offset)
+        total = albums
+        while len(albums) == size:
+            # try getting more albums
+            offset = offset + size
+            albums = self.get_more_albums(ltype, size, offset)
+            total = total + albums
+        return total
 
     def get_albums_as_refs(self, artist_id=None):
         albums = (

--- a/mopidy_subidy/subsonic_api.py
+++ b/mopidy_subidy/subsonic_api.py
@@ -412,7 +412,9 @@ class SubsonicApi:
 
     def get_more_albums(self, ltype, size=MAX_LIST_RESULTS, offset=0):
         try:
-            response = self.connection.getAlbumList2(ltype=ltype, size=size, offset=offset)
+            response = self.connection.getAlbumList2(
+                ltype=ltype, size=size, offset=offset
+            )
         except Exception:
             logger.warning(
                 "Connecting to subsonic failed when loading album list."


### PR DESCRIPTION
Fixes #30. As I mentioned in #30, even though supysonic ignores the spec's album size limit of 500, there's no guarantee all subsonic server implementations will ignore it so it's better to make repeat requests